### PR TITLE
Add mkdir in Installation instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,12 +37,10 @@ to even consider.
 
 ## Installation
 
-If you don't have a preferred installation method, I recommend
-installing [pathogen.vim](https://github.com/tpope/vim-pathogen), and
-then simply copy and paste:
+Install using your favourite package manager, or use Vim's built-in package support:
 
-    mkdir -p ~/.vim/bundle
-    cd ~/.vim/bundle
+    mkdir -p ~/.vim/pack/tpope/start
+    cd ~/.vim/pack/tpope/start
     git clone https://github.com/tpope/vim-vinegar.git
 
 ## Promotion

--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,7 @@ If you don't have a preferred installation method, I recommend
 installing [pathogen.vim](https://github.com/tpope/vim-pathogen), and
 then simply copy and paste:
 
+    mkdir -p ~/.vim/bundle
     cd ~/.vim/bundle
     git clone https://github.com/tpope/vim-vinegar.git
 


### PR DESCRIPTION
If this is the first bundle the user is installing, the directory ~/.vim/bundle may well not already exist, in which case the provided instructions would not at all achieve the desired result.  In fact the `cd` would fail and then `git clone` would drop a copy of pathogen in whatever directory the user happened to be in.

It might be better still to make the commands conditional on each other, as in `mkdir -p ~/.vim/bundle && cd ~/.vim/bundle && git clone ...` but for this PR I'm keeping it simple.